### PR TITLE
Task/80 remove the requirement for https prefix in request

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,29 @@
+name: Run Flake8
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  checkout-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        # Match the server version
+        python-version: '3.12.3'
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install flake8
+    - name: Run Flake8
+      run: |
+        flake8

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,29 @@
+name: Run Pytest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  checkout-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        # Match the server version
+        python-version: '3.12.3'
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install pytest
+    - name: Run Pytest
+      run: |
+        pytest --verbose

--- a/src/.flake8
+++ b/src/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=85

--- a/src/test_serve.py
+++ b/src/test_serve.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python3
-
-import pytest
-
 from serve import rewrite_html_urls, simplify_path, ServeLevelDB
+
 
 def test_relative_paths():
     """
@@ -17,6 +14,7 @@ def test_relative_paths():
         == b'<a href="../foo.html">'
     )
 
+
 def test_absolute_paths():
     """
     Check that we handle absolute paths correctly
@@ -30,9 +28,13 @@ def test_absolute_paths():
         == b'<a href="/hivrisk.cdc.gov/foo.html">'
     )
     assert (
-        rewrite_html_urls("hivrisk.cdc.gov/", b'<link rel="shortcut icon" href="/TemplatePackage/4.0/assets/imgs/favicon.ico">')
-        == b'<link rel="shortcut icon" href="/hivrisk.cdc.gov/TemplatePackage/4.0/assets/imgs/favicon.ico">'
+        rewrite_html_urls(
+            "hivrisk.cdc.gov/",
+            b'<link rel="shortcut icon" href="/favicon.ico">'
+        )
+        == b'<link rel="shortcut icon" href="/hivrisk.cdc.gov/favicon.ico">'
     )
+
 
 def test_full_urls():
     """
@@ -51,6 +53,7 @@ def test_full_urls():
         == b'<a href="/hivrisk.cdc.gov/foo.html">'
     )
 
+
 def test_other_subdomains():
     """
     Check that we aren't just redirecting everything to hivrisk
@@ -61,7 +64,8 @@ def test_other_subdomains():
         )
         == b"<a href='/nccd.cdc.gov/foo.html'>"
     )
-    
+
+
 def test_src_rewrites():
     """
     Check that we rewrite src as well as href
@@ -78,6 +82,7 @@ def test_src_rewrites():
         )
         == b'<img src="/hivrisk.cdc.gov/img.jpg">'
     )
+
 
 class MyServeLevelDB(ServeLevelDB):
     """
@@ -97,6 +102,7 @@ class MyServeLevelDB(ServeLevelDB):
             b"https://nccd.cdc.gov/favicon.ico": b"image/x-icon"
         }
 
+
 def test_find_content():
     """
     Check that we find the content with or without a trailing slash
@@ -115,6 +121,7 @@ def test_find_content():
         == (b"<p>Welcome to hivrisk.cdc.gov</p>", "text/html")
     )
 
+
 def test_find_content_mimetypes():
     """
     Check that we return other mime types
@@ -127,6 +134,7 @@ def test_find_content_mimetypes():
         == (b"1234", "image/x-icon")
     )
 
+
 def test_find_content_not_found():
     """
     Check how we respond for a request for something we don't have
@@ -138,6 +146,7 @@ def test_find_content_not_found():
         db.find_content("https://nccd.cdc.gov/page-definitely-not-there.html")
         == (None, None)
     )
+
 
 def test_simplify_path():
     """


### PR DESCRIPTION
Doing this in multiple steps (commits)

- First commit reorganizes the code so we can add some tests around it, and creates a few in preparation for the next stage.
- Second commit adds the support for getting rid of the `http:` and https:` prefixes, and 1 or 2 `/` after that, and adapts the tests and introduces a new one.
- Third commit adds a GitHub workflow to run the tests automatically for any PR and merge, going forward.
- Fourth commit adds a GitHub workflow to run flake8 automatically, with one custom setting (max line length 85 instead of 79) and updates the source code so it will pass.